### PR TITLE
add keymap to close the buffer under the cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Snipe.config = {
     position = "topleft",
   },
   hints = {
-    -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)
+    -- Characters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)
     dictionary = "sadflewcmpghio",
   },
   navigate = {
@@ -80,6 +80,11 @@ Snipe.config = {
     -- In case you changed your mind, provide a keybind that lets you
     -- cancel the snipe and close the window.
     cancel_snipe = "<esc>",
+
+    -- Close the buffer under the cursor
+    -- Remove "j" and "k" from your dictionary to navigate easier to delete
+    -- NOTE: Make sure you don't use the character below in your dictionary
+    close_buffer = "D",
   },
 }
 ```

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -33,6 +33,11 @@ Snipe.config = {
     -- In case you changed your mind, provide a keybind that lets you
     -- cancel the snipe and close the window.
     cancel_snipe = "<esc>",
+
+    -- Close the buffer under the cursor
+    -- Remove "j" and "k" from your dictionary to navigate easier to delete
+    -- NOTE: Make sure you don't use the character below on your dictionary
+    close_buffer = "D",
   },
 }
 
@@ -180,6 +185,23 @@ Snipe.menu = function(producer, callback)
 
     vim.keymap.set("n", Snipe.config.navigate.cancel_snipe, function()
       close()
+    end, { nowait = true, buffer = state.buffer })
+
+    vim.keymap.set("n", Snipe.config.navigate.close_buffer, function()
+      local cursor_pos = vim.api.nvim_win_get_cursor(state.window)
+      local line_count = vim.api.nvim_buf_line_count(state.buffer)
+      local at_last_line = cursor_pos[1] == line_count
+      local line_before_closing = cursor_pos[1]
+      local bufnr = meta[line_before_closing]
+      close()
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+      open()
+      local new_line_count = vim.api.nvim_buf_line_count(state.buffer)
+      if at_last_line then
+        vim.api.nvim_win_set_cursor(state.window, { new_line_count, 0 })
+      else
+        vim.api.nvim_win_set_cursor(state.window, { math.min(line_before_closing, new_line_count), 0 })
+      end
     end, { nowait = true, buffer = state.buffer })
   end
 


### PR DESCRIPTION
Hey, I'm loving the plugin so far.

I find this feature really useful when using BufExplorer, sometimes you're navigating through your open buffers and you want to close some, instead of jumping to them. The default keymap is "d" but In the pull request I set it to "D" to avoid issues with the default dictionary.

Let me know if it helps or if you have questions!