### PR TITLE
set buftype=nofile, buffer is not related to a file, will not be written

### DIFF
--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -75,6 +75,9 @@ Snipe.menu = function(producer, callback)
       -- Create fresh window and buffer
       state.buffer = H.create_buffer()
       state.window = window_unset
+      -- Set buffer options:
+      --   buftype=nofile, buffer is not related to a file, will not be written
+      vim.api.nvim_buf_set_option(state.buffer, 'buftype', 'nofile')
     end
 
     local meta, items = producer()

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -77,7 +77,7 @@ Snipe.menu = function(producer, callback)
       state.window = window_unset
       -- Set buffer options:
       --   buftype=nofile, buffer is not related to a file, will not be written
-      vim.api.nvim_buf_set_option(state.buffer, 'buftype', 'nofile')
+      vim.bo[state.buffer].buftype = "nofile"
     end
 
     local meta, items = producer()


### PR DESCRIPTION
Setting this option fixes the error of getting

    E37: No write since last change
    E162: No write since last change for buffer "[No Name]"

when executing `:qa` from the Snipe buffer.

This also helps plugins respecting this option like `tris203/precognition.nvim` to not interact with buffers that it is not supposed to.

See https://neovim.io/doc/user/options.html#'buftype'