### PR TITLE
feat: add option to sort buffers by latest accessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Snipe.config = {
     -- cancel the snipe and close the window.
     cancel_snipe = "<esc>",
   },
+  -- Define the way buffers are sorted by default
+  -- Can be any of "default" (sort buffers by their number) or "last" (sort buffers by last accessed)
+  sort = "default"
 }
 ```
 

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -35,7 +35,7 @@ Snipe.config = {
     cancel_snipe = "<esc>",
   },
   -- The default sort used for the buffers
-  -- Can be any of "last", (sort buffers by last opened) "default" (sort buffers by its number)
+  -- Can be any of "last", (sort buffers by last accessed) "default" (sort buffers by its number)
   sort = "default"
 }
 

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -34,6 +34,9 @@ Snipe.config = {
     -- cancel the snipe and close the window.
     cancel_snipe = "<esc>",
   },
+  -- The default sort used for the buffers
+  -- Can be any of "last", (sort buffers by last opened) "default" (sort buffers by its number)
+  sort = "default"
 }
 
 --- Creates a snipe menu
@@ -230,46 +233,78 @@ Snipe.open_buffer_menu = function(bopts_)
   Snipe.create_buffer_menu_toggler(bopts_)()
 end
 
+-- Helper function used to explode a string at a certain separator
+-- Used for the "last" sort option
+local function explode_string(str, sep)
+    if sep == nil then
+        sep = "|"
+    end
+    local t = {}
+    for s in str:gmatch("([^"..sep.."]+)") do
+        table.insert(t, s)
+    end
+    return t
+end
+
 --- Buffer producer lists open buffers
 ---
 ---@return table<integer>, table<string>
 Snipe.buffer_producer = function(opts_)
   local opts = opts_ or {}
 
-  local bufnrs = vim.tbl_filter(function (b)
-    return vim.fn.buflisted(b) == 1
-  end, vim.api.nvim_list_bufs())
+  local bufnrs = {}
+  local bufnames = {}
 
-  local bufnames = vim.tbl_map(function (b)
+  if Snipe.config.sort == "default" then
+    -- Get the buffers number
+    bufnrs = vim.tbl_filter(function (b)
+      return vim.fn.buflisted(b) == 1
+    end, vim.api.nvim_list_bufs())
 
-    local name = vim.fn.bufname(b)
-    if #name == 0 then
-      return "[No Name]"
-    end
+    -- Get the buffers name
+    bufnames = vim.tbl_map(function (b)
 
-    local res = name:gsub(vim.env.HOME, "~", 1)
-
-    if opts.max_path_width ~= nil then
-      local rem = name
-      res = ""
-      for _ = 1, opts.max_path_width do
-        if vim.fs.dirname(rem) == rem then
-          break
-        end
-        if res ~= "" then
-          res = "/" .. res
-        end
-        if rem == vim.env.HOME then
-          res = "~" .. res
-        else
-          res = vim.fs.basename(rem) .. res
-        end
-        rem = vim.fs.dirname(rem)
+      local name = vim.fn.bufname(b)
+      if #name == 0 then
+        return "[No Name]"
       end
-    end
 
-    return res
-  end, bufnrs)
+      local res = name:gsub(vim.env.HOME, "~", 1)
+
+      if opts.max_path_width ~= nil then
+        local rem = name
+        res = ""
+        for _ = 1, opts.max_path_width do
+          if vim.fs.dirname(rem) == rem then
+            break
+          end
+          if res ~= "" then
+            res = "/" .. res
+          end
+          if rem == vim.env.HOME then
+            res = "~" .. res
+          else
+            res = vim.fs.basename(rem) .. res
+          end
+          rem = vim.fs.dirname(rem)
+        end
+      end
+
+      return res
+    end, bufnrs)
+  elseif Snipe.config.sort == "last" then
+    local buffers = vim.api.nvim_exec2("ls t", { output = true })
+
+    ---@type string buf
+    for _, buf in ipairs(explode_string(buffers["output"], '\n')) do
+      local bufnr = string.match(buf, '%d+')
+      local bufname = string.match(buf, '".*"'):gsub('"', '')
+
+      table.insert(bufnrs, tonumber(bufnr))
+      table.insert(bufnames, bufname)
+    end
+  end
+
 
   return bufnrs, bufnames
 end

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -235,7 +235,7 @@ end
 
 -- Helper function used to explode a string at a certain separator
 -- Used for the "last" sort option
-local function explode_string(str, sep)
+H.explode_string = function(str, sep)
   local t = {}
   for s in str:gmatch("([^"..sep.."]+)") do
       table.insert(t, s)
@@ -243,7 +243,8 @@ local function explode_string(str, sep)
   return t
 end
 
-local function get_buffer_name(bufnr, opts)
+-- Return the buffer name from its buffer number
+H.get_buffer_name = function(bufnr, opts)
   local name = vim.fn.bufname(bufnr)
   if #name == 0 then
     return "[No Name]"
@@ -290,18 +291,18 @@ Snipe.buffer_producer = function(opts_)
 
     -- Get the buffers name
     bufnames = vim.tbl_map(function (b)
-      return get_buffer_name(b, opts)
+      return H.get_buffer_name(b, opts)
     end, bufnrs)
   elseif Snipe.config.sort == "last" then
     local buffers = vim.api.nvim_exec2("ls t", { output = true })
 
-    ---@type string buf
-    for _, buf in ipairs(explode_string(buffers["output"], '\n')) do
+    --- @type string buf
+    for _, buf in ipairs(H.explode_string(buffers["output"], '\n')) do
       local bufnr = tonumber(string.match(buf, '%d+'))
 
       if vim.fn.buflisted(bufnr) then
         table.insert(bufnrs, bufnr)
-        table.insert(bufnames, get_buffer_name(bufnr, opts))
+        table.insert(bufnames, H.get_buffer_name(bufnr, opts))
       end
     end
   end

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -297,11 +297,13 @@ Snipe.buffer_producer = function(opts_)
 
     ---@type string buf
     for _, buf in ipairs(explode_string(buffers["output"], '\n')) do
-      local bufnr = string.match(buf, '%d+')
+      local bufnr = tonumber(string.match(buf, '%d+'))
       local bufname = string.match(buf, '".*"'):gsub('"', '')
 
-      table.insert(bufnrs, tonumber(bufnr))
-      table.insert(bufnames, bufname)
+      if vim.fn.buflisted(bufnr) then
+        table.insert(bufnrs, bufnr)
+        table.insert(bufnames, bufname)
+      end
     end
   end
 


### PR DESCRIPTION
Hello !
This plugin is really awesome but the way the buffers are showed by default sometimes really annoys me (they’re sorted by their number). So I added a way to sort them by last focused.

It uses a configuration key named `sort` and can be `default` (sorted by numbers) or `last` (last accessed). Under the hood, it simply uses the `:ls t` command.

Have a nice day !