### PR TITLE
feat: add menu context passed to SnipeCreateBuffer autocmd

### DIFF
--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -46,10 +46,12 @@ Snipe.config = {
 --- being the string value of the item to show
 ---
 ---@generic T
+---@generic M
 ---@param producer fun(): table<T>, table<string> (function) Function
 ---@param callback fun(meta: T, index: integer) (function) Function
+---@param menu_context ?M
 ---@return table { open = fun(), close = fun(), is_open = fun() } : Table of menu functions
-Snipe.menu = function(producer, callback)
+Snipe.menu = function(producer, callback, menu_context)
   local window_unset = -1
   local buffer = H.create_buffer()
   local state = {
@@ -148,6 +150,7 @@ Snipe.menu = function(producer, callback)
           open = open,
           close = close,
           is_open = is_open,
+          menu_context = menu_context,
         },
         buf = state.buffer,
       },
@@ -203,10 +206,12 @@ end
 --- closed
 ---
 ---@generic T
+---@generic M
 ---@param producer fun(): table<T>, table<string> (function) Function
 ---@param callback fun(meta: T, index: integer) (function) Function
-Snipe.create_menu_toggler = function(producer, callback)
-  local menu = Snipe.menu(producer, callback)
+---@param menu_context ?M
+Snipe.create_menu_toggler = function(producer, callback, menu_context)
+  local menu = Snipe.menu(producer, callback, menu_context)
   return function()
     if menu.is_open() then
       menu.close()


### PR DESCRIPTION
Hello, I've been loving the plugin so far. This is just a small modification I made to improve my experience that might be beneficial for other people

# Description

This PR adds a `menu_context` argument to [Snipe.menu](https://github.com/leath-dub/snipe.nvim/blob/main/lua/snipe/init.lua#L52) and to [Snipe.create_menu_toggler](https://github.com/leath-dub/snipe.nvim/blob/main/lua/snipe/init.lua#L208) (which just passes it down to `Snipe.menu`). This is an opaque argument that is never directly used by the plugin. This `menu_context` is simply passed down to the `SnipeCreateBuffer`'s autocmd data argument, so it can be consumed by whoever listens to this autocmd

# Background

I've been tackling #14 for a bit because I wanted to implement a way to delete buffers, and not just open them.

My solution was to create two menus using the [create_menu_toggler](https://github.com/leath-dub/snipe.nvim/blob/main/lua/snipe/init.lua#L222) function, one for opening buffers, and the other for deleting them. Then, using the `SnipeCreateBuffer` autocmd, I'd register on them the keymaps to open each other.

However, the `SnipeCreateBuffer` autocmd has no way to know from which menu it was triggered. This means I could not run a piece of code on only the closing menu, as I wanted. I then forked the project and just added this opaque argument that's just passed down to the autocmd trigger. This is mostly inspired by how producers will have an opaque meta-data that's simply passed down to the menu's callback.

Even though I made this change specifically to solve a personal problem of mine, I think this change will make the plugin more flexible and extensible, and could benefit other people :)

Obs: [this](https://github.com/Jeansidharta/neovim-flake/blob/f129a1b6b018efac0f2fead75f5d8212167f75d3/config/lua/plugins/snipe.lua) is how my implementation of the two menus looks, with this change