### PR TITLE
feat: show marker if buffers have unsaved changes

### DIFF
--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -287,6 +287,10 @@ H.get_buffer_name = function(bufnr, opts)
 
   local res = name:gsub(vim.env.HOME, "~", 1)
 
+  if vim.api.nvim_get_option_value("modified", { buf = bufnr }) then
+    return res .. " [m]"
+  end
+
   if opts.max_path_width ~= nil then
     local rem = name
     res = ""


### PR DESCRIPTION
I'm a fan of the buffer close functionality, but I'm lacking an indicator on usaved buffers. This PR achieves this, but there's probably room for improvement. This change adds an `[m]` suffix to any buffer with unsaved changes.