### PR TITLE
fix(cursorline): Remove hard-coding of `cursorline` option

### DIFF
--- a/lua/snipe/menu.lua
+++ b/lua/snipe/menu.lua
@@ -273,7 +273,7 @@ function Menu:update_window(height, width)
   vim.api.nvim_win_set_hl_ns(self.win, H.highlight_ns)
   vim.wo[self.win].foldenable = false
   vim.wo[self.win].wrap = false
-  vim.wo[self.win].cursorline = true
+  -- vim.wo[self.win].cursorline = true
 end
 
 function Menu:create_window(bufnr, height, width)
@@ -282,7 +282,7 @@ function Menu:create_window(bufnr, height, width)
   vim.api.nvim_win_set_hl_ns(win, H.highlight_ns)
   vim.wo[win].foldenable = false
   vim.wo[win].wrap = false
-  vim.wo[win].cursorline = true
+  -- vim.wo[win].cursorline = true
 
   return win
 end


### PR DESCRIPTION
The menu was changing the `cursorline` option to true even though I had cursorline set to false. I commented the lines that were changing the option and it looks like it fixed the issue.

If there are issues with this aproach please tell me and I'll go fix them.

Thank you for the great plugin!