### PR TITLE
refactor(config): extract main config and use it in menu module default config

### DIFF
--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -1,0 +1,126 @@
+---@class snipe.Config: snipe.DefaultConfig
+M = {}
+
+---@class snipe.DefaultConfig
+M.defaults = {
+  ui = {
+    max_height = -1, -- -1 means dynamic height
+    -- Where to place the ui window
+    -- Can be any of "topleft", "bottomleft", "topright", "bottomright", "center", "cursor" (sets under the current cursor pos)
+    position = "topleft",
+    -- Override options passed to `nvim_open_win`
+    -- Be careful with this as snipe will not validate
+    -- anything you override here. See `:h nvim_open_win`
+    -- for config options
+    open_win_override = {
+      -- title = "My Window Title",
+      border = "single", -- use "rounded" for rounded border
+    },
+
+    -- Preselect the currently open buffer
+    preselect_current = false,
+
+    -- Set a function to preselect the currently open buffer
+    -- E.g, `preselect = require("snipe").preselect_by_classifier("#")` to
+    -- preselect alternate buffer (see :h ls and look at the "Indicators")
+    preselect = nil, -- function (bs: Buffer[] [see lua/snipe/buffer.lua]) -> int (index)
+
+    -- Changes how the items are aligned: e.g. "<tag> foo    " vs "<tag>    foo"
+    -- Can be "left", "right" or "file-first"
+    -- NOTE: "file-first" buts the file name first and then the directory name
+    text_align = "left",
+  },
+  hints = {
+    -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)
+    dictionary = "sadflewcmpghio",
+  },
+  navigate = {
+    -- When the list is too long it is split into pages
+    -- `[next|prev]_page` options allow you to navigate
+    -- this list
+    next_page = "J",
+    prev_page = "K",
+
+    -- You can also just use normal navigation to go to the item you want
+    -- this option just sets the keybind for selecting the item under the
+    -- cursor
+    under_cursor = "<cr>",
+
+    -- In case you changed your mind, provide a keybind that lets yu
+    -- cancel the snipe and close the window.
+    cancel_snipe = "<esc>",
+
+    -- Close the buffer under the cursor
+    -- Remove "j" and "k" from your dictionary to navigate easier to delete
+    -- NOTE: Make sure you don't use the character below on your dictionary
+    close_buffer = "D",
+
+    -- Open buffer in vertical split
+    open_vsplit = "V",
+
+    -- Open buffer in split, based on `vim.opt.splitbelow`
+    open_split = "H",
+
+    -- Change tag manually
+    change_tag = "C",
+  },
+  -- The default sort used for the buffers
+  -- Can be any of "last", (sort buffers by last accessed) "default" (sort buffers by its number)
+  sort = "default",
+}
+
+M.options = vim.deepcopy(M.defaults)
+
+M.validate = function(config)
+  vim.validate({ config = { config, "table", true } })
+
+  local validation_set = {
+    ["ui.max_width"] = { config.ui.max_width, "number", true },
+    ["ui.position"] = { config.ui.position, "string", true },
+    ["ui.open_win_override"] = { config.ui.open_win_override, "table", true },
+    ["ui.preselect_current"] = { config.ui.preselect_current, "boolean", true },
+    ["ui.preselect"] = { config.ui.preselect, "function", true },
+    ["ui.text_align"] = { config.ui.text_align, "string", true },
+    ["hints.dictionary"] = { config.hints.dictionary, "string", true },
+    ["navigate.next_page"] = { config.navigate.next_page, "string", true },
+    ["navigate.prev_page"] = { config.navigate.prev_page, "string", true },
+    ["navigate.under_cursor"] = { config.navigate.under_cursor, "string", true },
+    ["navigate.cancel_snipe"] = { config.navigate.cancel_snipe, "string", true },
+    ["navigate.close_buffer"] = { config.navigate.close_buffer, "string", true },
+    ["navigate.open_vsplit"] = { config.navigate.open_vsplit, "string", true },
+    ["navigate.open_split"] = { config.navigate.open_split, "string", true },
+    ["navigate.change_tag"] = { config.navigate.change_tag, "string", true },
+    ["sort"] = { config.sort, "string", true },
+  }
+
+  vim.validate(validation_set)
+
+  -- Make sure they are not using preselect_current and preselect
+  if config.ui.preselect ~= nil and config.ui.preselect_current then
+    vim.notify("(snipe) Conflicting options: ui.preselect_current is set true while ui.preselect is not nil")
+  end
+
+  -- Validate hint characters and setup tables
+  if #config.hints.dictionary < 2 then
+    vim.notify("(snipe) Dictionary must have at least 2 items", vim.log.levels.ERROR)
+    return config
+  end
+
+  return true
+end
+
+M.setup = function(user_config)
+  local config = vim.tbl_deep_extend("force", M.options, user_config or {})
+
+  if M.validate(config) then
+    M.options = config
+  end
+end
+
+setmetatable(M, {
+  __index = function(_, k)
+    return M.options[k]
+  end,
+})
+
+return M

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -3,6 +3,8 @@ local Config = require("snipe.config")
 
 Snipe.setup = function(config)
   Config.setup(config)
+  --- @deprecated Snipe.config is deprecated, use require('snipe.config') instead
+  Snipe.config = Config
 
   local SnipeMenu = require("snipe.menu")
   Snipe.global_menu = SnipeMenu:new({

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -1,127 +1,15 @@
 local Snipe = {}
-local H = {}
+local Config = require("snipe.config")
 
 Snipe.setup = function(config)
-  Snipe.config = H.setup_config(config)
+  Config.setup(config)
 
   local SnipeMenu = require("snipe.menu")
   Snipe.global_menu = SnipeMenu:new({
-    dictionary = Snipe.config.hints.dictionary,
-    position = Snipe.config.ui.position,
-    open_win_override = Snipe.config.ui.open_win_override,
-    max_height = Snipe.config.ui.max_height,
-    align = Snipe.config.ui.text_align == "file-first" and "left" or Snipe.config.ui.text_align,
     map_tags = Snipe.default_map_tags,
     set_window_local_options = Snipe.set_window_local_options,
   })
   Snipe.global_items = {}
-end
-
-H.default_config = {
-  ui = {
-    max_height = -1, -- -1 means dynamic height
-    -- Where to place the ui window
-    -- Can be any of "topleft", "bottomleft", "topright", "bottomright", "center", "cursor" (sets under the current cursor pos)
-    position = "topleft",
-    -- Override options passed to `nvim_open_win`
-    -- Be careful with this as snipe will not validate
-    -- anything you override here. See `:h nvim_open_win`
-    -- for config options
-    open_win_override = {
-      -- title = "My Window Title",
-      border = "single", -- use "rounded" for rounded border
-    },
-
-    -- Preselect the currently open buffer
-    preselect_current = false,
-
-    -- Set a function to preselect the currently open buffer
-    -- E.g, `preselect = require("snipe").preselect_by_classifier("#")` to
-    -- preselect alternate buffer (see :h ls and look at the "Indicators")
-    preselect = nil, -- function (bs: Buffer[] [see lua/snipe/buffer.lua]) -> int (index)
-
-    -- Changes how the items are aligned: e.g. "<tag> foo    " vs "<tag>    foo"
-    -- Can be "left", "right" or "file-first"
-    -- NOTE: "file-first" buts the file name first and then the directory name
-    text_align = "left",
-  },
-  hints = {
-    -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)
-    dictionary = "sadflewcmpghio",
-  },
-  navigate = {
-    -- When the list is too long it is split into pages
-    -- `[next|prev]_page` options allow you to navigate
-    -- this list
-    next_page = "J",
-    prev_page = "K",
-
-    -- You can also just use normal navigation to go to the item you want
-    -- this option just sets the keybind for selecting the item under the
-    -- cursor
-    under_cursor = "<cr>",
-
-    -- In case you changed your mind, provide a keybind that lets you
-    -- cancel the snipe and close the window.
-    cancel_snipe = "<esc>",
-
-    -- Close the buffer under the cursor
-    -- Remove "j" and "k" from your dictionary to navigate easier to delete
-    -- NOTE: Make sure you don't use the character below on your dictionary
-    close_buffer = "D",
-
-    -- Open buffer in vertical split
-    open_vsplit = "V",
-
-    -- Open buffer in split, based on `vim.opt.splitbelow`
-    open_split = "H",
-
-    -- Change tag manually
-    change_tag = "C",
-  },
-  -- The default sort used for the buffers
-  -- Can be any of "last", (sort buffers by last accessed) "default" (sort buffers by its number)
-  sort = "default",
-}
-
-H.setup_config = function(config)
-  config = config or {}
-  vim.validate({ config = { config, "table", true } })
-  config = vim.tbl_deep_extend("force", vim.deepcopy(H.default_config), config)
-
-  local validation_set = {
-    ["ui.max_width"] = { config.ui.max_width, "number", true },
-    ["ui.position"] = { config.ui.position, "string", true },
-    ["ui.open_win_override"] = { config.ui.open_win_override, "table", true },
-    ["ui.preselect_current"] = { config.ui.preselect_current, "boolean", true },
-    ["ui.preselect"] = { config.ui.preselect, "function", true },
-    ["ui.text_align"] = { config.ui.text_align, "string", true },
-    ["hints.dictionary"] = { config.hints.dictionary, "string", true },
-    ["navigate.next_page"] = { config.navigate.next_page, "string", true },
-    ["navigate.prev_page"] = { config.navigate.prev_page, "string", true },
-    ["navigate.under_cursor"] = { config.navigate.under_cursor, "string", true },
-    ["navigate.cancel_snipe"] = { config.navigate.cancel_snipe, "string", true },
-    ["navigate.close_buffer"] = { config.navigate.close_buffer, "string", true },
-    ["navigate.open_vsplit"] = { config.navigate.open_vsplit, "string", true },
-    ["navigate.open_split"] = { config.navigate.open_split, "string", true },
-    ["navigate.change_tag"] = { config.navigate.change_tag, "string", true },
-    ["sort"] = { config.sort, "string", true },
-  }
-
-  vim.validate(validation_set)
-
-  -- Make sure they are not using preselect_current and preselect
-  if config.ui.preselect ~= nil and config.ui.preselect_current then
-    vim.notify("(snipe) Conflicting options: ui.preselect_current is set true while ui.preselect is not nil")
-  end
-
-  -- Validate hint characters and setup tables
-  if #config.hints.dictionary < 2 then
-    vim.notify("(snipe) Dictionary must have at least 2 items", vim.log.levels.ERROR)
-    return config
-  end
-
-  return config
 end
 
 function Snipe.set_window_local_options(wid)
@@ -150,9 +38,9 @@ function Snipe.default_keymaps(m)
     m:reopen()
   end
 
-  vim.keymap.set("n", Snipe.config.navigate.next_page, nav_next, { nowait = true, buffer = m.buf })
-  vim.keymap.set("n", Snipe.config.navigate.prev_page, nav_prev, { nowait = true, buffer = m.buf })
-  vim.keymap.set("n", Snipe.config.navigate.close_buffer, function()
+  vim.keymap.set("n", Config.navigate.next_page, nav_next, { nowait = true, buffer = m.buf })
+  vim.keymap.set("n", Config.navigate.prev_page, nav_prev, { nowait = true, buffer = m.buf })
+  vim.keymap.set("n", Config.navigate.close_buffer, function()
     local hovered = m:hovered()
     local bufnr = m.items[hovered].id
     -- I have to hack switch back to main window, otherwise currently background focused
@@ -165,29 +53,29 @@ function Snipe.default_keymaps(m)
     m:reopen()
   end, { nowait = true, buffer = m.buf })
 
-  vim.keymap.set("n", Snipe.config.navigate.open_vsplit, function()
+  vim.keymap.set("n", Config.navigate.open_vsplit, function()
     local bufnr = m.items[m:hovered()].id
     m:close() -- make sure to call first !
     vim.api.nvim_open_win(bufnr, true, { vertical = true, win = 0 })
   end, { nowait = true, buffer = m.buf })
 
-  vim.keymap.set("n", Snipe.config.navigate.open_split, function()
+  vim.keymap.set("n", Config.navigate.open_split, function()
     local split_direction = vim.opt.splitbelow:get() and "below" or "above"
     local bufnr = m.items[m:hovered()].id
     m:close() -- make sure to call first !
     vim.api.nvim_open_win(bufnr, true, { split = split_direction, win = 0 })
   end, { nowait = true, buffer = m.buf })
 
-  vim.keymap.set("n", Snipe.config.navigate.cancel_snipe, function()
+  vim.keymap.set("n", Config.navigate.cancel_snipe, function()
     m:close()
   end, { nowait = true, buffer = m.buf })
-  vim.keymap.set("n", Snipe.config.navigate.under_cursor, function()
+  vim.keymap.set("n", Config.navigate.under_cursor, function()
     local hovered = m:hovered()
     m:close()
     vim.api.nvim_set_current_buf(m.items[hovered].id)
   end, { nowait = true, buffer = m.buf })
 
-  vim.keymap.set("n", Snipe.config.navigate.change_tag, function()
+  vim.keymap.set("n", Config.navigate.change_tag, function()
     local item_id = m:hovered()
     vim.ui.input({ prompt = "Enter custom tag: " }, function(input)
       table.insert(Snipe.index_to_tag, { index = item_id, tag = input })
@@ -257,17 +145,17 @@ function Snipe.preselect_by_classifier(classifier)
 end
 
 function Snipe.open_buffer_menu()
-  local cmd = Snipe.config.sort == "last" and "ls t" or "ls"
+  local cmd = Config.sort == "last" and "ls t" or "ls"
   Snipe.global_items = require("snipe.buffer").get_buffers(cmd)
-  if Snipe.config.ui.text_align == "file-first" then
+  if Config.ui.text_align == "file-first" then
     Snipe.global_items = Snipe.file_first_format(Snipe.global_items)
   end
   Snipe.global_menu:add_new_buffer_callback(Snipe.default_keymaps)
 
-  if Snipe.config.ui.preselect then
-    local i = Snipe.config.ui.preselect(Snipe.global_items)
+  if Config.ui.preselect then
+    local i = Config.ui.preselect(Snipe.global_items)
     Snipe.global_menu:open(Snipe.global_items, Snipe.default_select, Snipe.default_fmt, i)
-  elseif Snipe.config.ui.preselect_current then
+  elseif Config.ui.preselect_current then
     local opened = false
     for i, b in ipairs(Snipe.global_items) do
       if b.classifiers:sub(2, 2) == "%" then
@@ -302,7 +190,7 @@ function Snipe.ui_select(items, opts, on_choice)
     on_choice(m.items[i], i)
     m:close()
   end, opts.format_item)
-  Snipe.ui_select_menu.config.open_win_override.title = Snipe.config.ui.open_win_override.title
+  Snipe.ui_select_menu.config.open_win_override.title = Config.ui.open_win_override.title
 end
 
 return Snipe

--- a/lua/snipe/menu.lua
+++ b/lua/snipe/menu.lua
@@ -1,5 +1,7 @@
 local unset = -1
 
+local Config = require("snipe.config")
+
 local Menu = {
   config = {},
   dict = {},
@@ -28,13 +30,13 @@ local H = {}
 -- This config will only really apply if not
 -- being called through the high level interface (which pushes global config values down)
 H.default_config = {
-  dictionary = "sadflewcmpghio",
-  position = "topleft",
-  open_win_override = {},
+  dictionary = Config.hints.dictionary,
+  position = Config.ui.position,
+  open_win_override = Config.ui.open_win_override,
 
   -- unset means no maximum
-  max_height = unset,
-  align = "left", -- one of "right" and "left"
+  max_height = Config.ui.max_height,
+  align = Config.ui.text_align == 'right' and 'right' or 'left', -- one of "right" and "left"
   map_tags = nil, -- Apply map operation on generated tags
   set_window_local_options = function(wid)
     vim.wo[wid].foldenable = false


### PR DESCRIPTION
Extract main config to separate module and update default Menu config with main config values. This improves code readability and reusability.

## Description

I want to simplify integration with other plugins by adding default menu settings from the main config (less duplication). To make the config data usable everywhere, I moved it to a separate module.

## Current problem and solution

The current limitation is that when users install snipe and several [snipe-based plugins](https://github.com/leath-dub/snipe.nvim#projects-using-snipenvim), and they change the default settings, they need to update settings in all other plugins as well. This creates unnecessary code duplication. I think it would be better if the default menu settings were based on the main config, while plugin authors can still override values if needed.

For example, in my config I changed dictionary and cursor settings, but all plugins use default settings. So I had two choices: either contribute feature custom settings to each plugin individually, or contribute this PR to centralize settings, which is what I decided to do.