### PR TITLE
refactor(keymaps): move default keymaps to Menu module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ You can pass in a table of options to the `setup` function, here are the default
 
     -- In case you changed your mind, provide a keybind that lets you
     -- cancel the snipe and close the window.
+    ---@type string|string[]
     cancel_snipe = "<esc>",
 
     -- Close the buffer under the cursor

--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -48,6 +48,7 @@ M.defaults = {
 
     -- In case you changed your mind, provide a keybind that lets yu
     -- cancel the snipe and close the window.
+    ---@type string|string[]
     cancel_snipe = "<esc>",
 
     -- Close the buffer under the cursor
@@ -85,7 +86,7 @@ M.validate = function(config)
     ["navigate.next_page"] = { config.navigate.next_page, "string", true },
     ["navigate.prev_page"] = { config.navigate.prev_page, "string", true },
     ["navigate.under_cursor"] = { config.navigate.under_cursor, "string", true },
-    ["navigate.cancel_snipe"] = { config.navigate.cancel_snipe, "string", true },
+    ["navigate.cancel_snipe"] = { config.navigate.cancel_snipe, { "string", "table" }, true },
     ["navigate.close_buffer"] = { config.navigate.close_buffer, "string", true },
     ["navigate.open_vsplit"] = { config.navigate.open_vsplit, "string", true },
     ["navigate.open_split"] = { config.navigate.open_split, "string", true },

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -29,19 +29,19 @@ function Snipe.default_map_tags(tags)
   return tags
 end
 
+---@param m snipe.Menu
 function Snipe.default_keymaps(m)
-  local nav_next = function()
-    m:goto_next_page()
-    m:reopen()
-  end
+  m:default_keymaps({
+    under_cursor = function()
+      local hovered = m:hovered()
+      m:close()
+      vim.api.nvim_set_current_buf(m.items[hovered].id)
+    end,
+  })
 
-  local nav_prev = function()
-    m:goto_prev_page()
-    m:reopen()
-  end
+  local opts = { nowait = true, buffer = m.buf }
 
-  vim.keymap.set("n", Config.navigate.next_page, nav_next, { nowait = true, buffer = m.buf })
-  vim.keymap.set("n", Config.navigate.prev_page, nav_prev, { nowait = true, buffer = m.buf })
+  -- Specific keymaps
   vim.keymap.set("n", Config.navigate.close_buffer, function()
     local hovered = m:hovered()
     local bufnr = m.items[hovered].id
@@ -53,29 +53,20 @@ function Snipe.default_keymaps(m)
     vim.api.nvim_set_current_win(m.win)
     table.remove(m.items, hovered)
     m:reopen()
-  end, { nowait = true, buffer = m.buf })
+  end, opts)
 
   vim.keymap.set("n", Config.navigate.open_vsplit, function()
     local bufnr = m.items[m:hovered()].id
     m:close() -- make sure to call first !
     vim.api.nvim_open_win(bufnr, true, { vertical = true, win = 0 })
-  end, { nowait = true, buffer = m.buf })
+  end, opts)
 
   vim.keymap.set("n", Config.navigate.open_split, function()
     local split_direction = vim.opt.splitbelow:get() and "below" or "above"
     local bufnr = m.items[m:hovered()].id
     m:close() -- make sure to call first !
     vim.api.nvim_open_win(bufnr, true, { split = split_direction, win = 0 })
-  end, { nowait = true, buffer = m.buf })
-
-  vim.keymap.set("n", Config.navigate.cancel_snipe, function()
-    m:close()
-  end, { nowait = true, buffer = m.buf })
-  vim.keymap.set("n", Config.navigate.under_cursor, function()
-    local hovered = m:hovered()
-    m:close()
-    vim.api.nvim_set_current_buf(m.items[hovered].id)
-  end, { nowait = true, buffer = m.buf })
+  end, opts)
 
   vim.keymap.set("n", Config.navigate.change_tag, function()
     local item_id = m:hovered()
@@ -83,7 +74,7 @@ function Snipe.default_keymaps(m)
       table.insert(Snipe.index_to_tag, { index = item_id, tag = input })
       m:reopen()
     end)
-  end, { nowait = true, buffer = m.buf })
+  end, opts)
 end
 
 Snipe.directory_separator = "@"


### PR DESCRIPTION
## Description

I've extracted core keymaps (cancel, next_page, prev_page, under_cursor) into the Menu module.
I think these are essential keymaps that will be valuable for most Snipe-based plugin.
Only Snipe buffer-specific keymaps remain in init.lua.
I also added the ability to set multiple keys for cancel_snipe keymap because sometimes the user wants to set multiple keys for it, for example { 'q', '\<esc\>'}

## Use-cases

In a Snipe-based plugin, if an author wants to enable default keymaps, they can simply enable them and optionally customize the keys:

```lua
local Menu = require("snipe.menu")
local menu = Menu:new {
  default_keymaps = {
    auto_setup = true,
    cancel = { 'q', '<esc>' }
  }
}

menu:open(...)
```

If an author wants to keep default keymaps but add custom functionality (or doesn't want defaults), they can keep `auto_setup = false` and pass custom callbacks (snipe default behaviour):

```lua
local Menu = require("snipe.menu")
local menu = Menu:new()

menu:add_new_buffer_callback(function (m)
  -- If need default keymaps
  menu:default_keymaps({
    under_cursor = function (menu)
      -- custom under_cursor callback
    end
  })

  -- specific keymaps
end)

menu:open(...)
```

## NOTE

 I'm not sure if the auto_setup option is needed. In fact the user can simply do:

```lua
menu:add_new_buffer_callback(function()
  menu:default_keymaps()
end)
```

 But it just slightly simplifies the code if the default keymaps suit you.
