### PR TITLE
fix(c27c30a): Fix for change made in commit #c27c30a

### DIFF
--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -49,7 +49,7 @@ function Snipe.default_keymaps(m)
     -- window cannot be deleted when focused on a floating window
     m.opened_from_wid = m:open_over()
     vim.api.nvim_set_current_win(m.opened_from_wid)
-    vim.api.nvim_buf_delete(bufnr)
+    vim.api.nvim_buf_delete(bufnr, { force = false })
     vim.api.nvim_set_current_win(m.win)
     table.remove(m.items, hovered)
     m:reopen()


### PR DESCRIPTION
`nvim_buf_delete` needs an "options" object, since we want to not force the deletion of a buffer, use de object `{ force = false }` as a second argument.