### PR TITLE
Delete buffer on close

### DIFF
--- a/lua/snipe/menu.lua
+++ b/lua/snipe/menu.lua
@@ -269,8 +269,12 @@ function Menu:close()
   if self.win ~= unset and vim.api.nvim_win_is_valid(self.win) then
     vim.api.nvim_win_close(self.win, true)
   end
+  if self.buf ~= unset and vim.api.nvim_buf_is_valid(self.buf) then
+    vim.api.nvim_buf_delete(self.buf, { force = true })
+  end
 
   self.win = unset
+  self.buf = unset
 end
 
 function Menu:get_window_opts(height, width)


### PR DESCRIPTION
Issue:
The <cr> keymap (under_cursor) stops working after first use when navigating through multiple items

Cause: The buffer with keymaps persists after closing but isn't properly reinitialized when reopening

Fix: Either delete the buffer on close or use close_nosave

Reproduce:

1. Open buffer list with multiple items
2. Select an item with <cr>
3. Reopen buffer list
4. Try to select another item with <cr> - it won't work