### PR TITLE
Integrate snacks.bufdelete

### DIFF
--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -49,10 +49,14 @@ function Snipe.default_keymaps(m)
     -- window cannot be deleted when focused on a floating window
     m.opened_from_wid = m:open_over()
     vim.api.nvim_set_current_win(m.opened_from_wid)
-    -- vim.api.nvim_buf_delete(bufnr, { force = true })
-    -- ideally, should check if snacks.nvim is installed, otherwise do the
-    -- above
-    Snacks.bufdelete(bufnr)
+
+    local ok, snacks = pcall(require, "snacks")
+    if ok then
+      snacks.bufdelete(bufnr)
+    else
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+
     vim.api.nvim_set_current_win(m.win)
     table.remove(m.items, hovered)
     m:reopen()

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -54,7 +54,7 @@ function Snipe.default_keymaps(m)
     if ok then
       snacks.bufdelete(bufnr)
     else
-      vim.api.nvim_buf_delete(bufnr, { force = true })
+      vim.api.nvim_buf_delete(bufnr, { force = false })
     end
 
     vim.api.nvim_set_current_win(m.win)

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -49,7 +49,10 @@ function Snipe.default_keymaps(m)
     -- window cannot be deleted when focused on a floating window
     m.opened_from_wid = m:open_over()
     vim.api.nvim_set_current_win(m.opened_from_wid)
-    vim.api.nvim_buf_delete(bufnr, { force = true })
+    -- vim.api.nvim_buf_delete(bufnr, { force = true })
+    -- ideally, should check if snacks.nvim is installed, otherwise do the
+    -- above
+    Snacks.bufdelete(bufnr)
     vim.api.nvim_set_current_win(m.win)
     table.remove(m.items, hovered)
     m:reopen()


### PR DESCRIPTION
This commit adds a check to see if `snacks.nvim` is installed. If it is, the `snacks.bufdelete` function is used to close a buffer instead of `nvim_buf_delete`.

**What type of PR is this?**
bug

**Which issue(s) this PR fixes:**
fixes #65  

