### PR TITLE
Add support for custom highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ You can pass in a table of options to the `setup` function, here are the default
     -- Can be "left", "right" or "file-first"
     -- NOTE: "file-first" puts the file name first and then the directory name
     text_align = "left",
+
+    -- Provide custom buffer list format
+    -- Available options:
+    --  "filename" - basename of the buffer
+    --  "directory" - buffer parent directory path
+    --  "icon" - icon for buffer filetype from "mini.icons" or "nvim-web-devicons"
+    --  string - any string, will be inserted as is
+    --  fun(buffer_object): string,string - function that takes snipe.Buffer object as an argument
+    --    and returns a string to be inserted and optional highlight group name
+    -- buffer_format = { "->", "icon", "filename", "", "directory", function(buf)
+    --   if vim.fn.isdirectory(vim.api.nvim_buf_get_name(buf.id)) == 1 then
+    --     return " ", "SnipeText"
+    --   end
+    -- end },
   },
   hints = {
     -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can pass in a table of options to the `setup` function, here are the default
 
     -- Changes how the items are aligned: e.g. "<tag> foo    " vs "<tag>    foo"
     -- Can be "left", "right" or "file-first"
-    -- NOTE: "file-first" buts the file name first and then the directory name
+    -- NOTE: "file-first" puts the file name first and then the directory name
     text_align = "left",
   },
   hints = {

--- a/lua/snipe/buffer.lua
+++ b/lua/snipe/buffer.lua
@@ -3,8 +3,6 @@ local M = {}
 ---@class snipe.Buffer
 ---@field id integer buffer id
 ---@field name string full name of the buffer, as in ":ls" output
----@field basename string filename of the buffer
----@field dirname string parent directory path
 ---@field classifiers string see :help ls for more info
 
 ---@class snipe.Buffer
@@ -27,8 +25,6 @@ function Buffer:from_line(s)
   local se = #s - s:reverse():find('"')
 
   o.name = s:sub(ss + 1, se)
-  o.basename = vim.fs.basename(o.name)
-  o.dirname = vim.fs.dirname(o.name)
 
   return o
 end

--- a/lua/snipe/buffer.lua
+++ b/lua/snipe/buffer.lua
@@ -1,26 +1,34 @@
 local M = {}
 
-local Buffer = {
-  id = 0,
-  name = "",
-  classifiers = "     ", -- see :help ls for more info
-}
+---@class snipe.Buffer
+---@field id integer buffer id
+---@field name string full name of the buffer, as in ":ls" output
+---@field basename string filename of the buffer
+---@field dirname string parent directory path
+---@field classifiers string see :help ls for more info
+
+---@class snipe.Buffer
+local Buffer = {}
 
 Buffer.__index = Buffer
 
 M.Buffer = Buffer
 
--- Converts single line from ":buffers" output
+---create snipe.Buffer from ":ls" output string
+---@param s string - ":ls" output line, ie. '49 %a + "lua/snipe/buffer.lua"         line 18'
+---@return snipe.Buffer
 function Buffer:from_line(s)
   local o = setmetatable({}, Buffer)
 
-  o.id = tonumber(vim.split(s, " ", { trimempty = true })[1])
+  o.id = tonumber(vim.split(s, " ", { trimempty = true })[1]) --[[@as integer]]
   o.classifiers = s:sub(4, 8)
 
   local ss = s:find('"')
   local se = #s - s:reverse():find('"')
 
   o.name = s:sub(ss + 1, se)
+  o.basename = vim.fs.basename(o.name)
+  o.dirname = vim.fs.dirname(o.name)
 
   return o
 end

--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -27,7 +27,7 @@ M.defaults = {
 
     -- Changes how the items are aligned: e.g. "<tag> foo    " vs "<tag>    foo"
     -- Can be "left", "right" or "file-first"
-    -- NOTE: "file-first" buts the file name first and then the directory name
+    -- NOTE: "file-first" puts the file name first and then the directory name
     text_align = "left",
 
     -- Provide custom buffer list format

--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -29,6 +29,20 @@ M.defaults = {
     -- Can be "left", "right" or "file-first"
     -- NOTE: "file-first" buts the file name first and then the directory name
     text_align = "left",
+
+    -- Provide custom buffer list format
+    -- Available options:
+    --  "filename" - basename of the buffer
+    --  "directory" - buffer parent directory path
+    --  "icon" - icon for buffer filetype from "mini.icons" or "nvim-web-devicons"
+    --  string - any string, will be inserted as is
+    --  fun(buffer_object): string,string - function that takes snipe.Buffer object as an argument
+    --    and returns a string to be inserted and optional highlight group name
+    -- buffer_format = { "->", "icon", "filename", "", "directory", function(buf)
+    --   if vim.fn.isdirectory(vim.api.nvim_buf_get_name(buf.id)) == 1 then
+    --     return " ", "SnipeText"
+    --   end
+    -- end },
   },
   hints = {
     -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)

--- a/lua/snipe/highlights.lua
+++ b/lua/snipe/highlights.lua
@@ -3,7 +3,6 @@ local M = {}
 M.highlight_groups = {
   hint = {
     name = "SnipeHint",
-    -- definition = { link = "CursorLineNr" },
     definition = { link = "Boolean" },
   },
   text = {

--- a/lua/snipe/highlights.lua
+++ b/lua/snipe/highlights.lua
@@ -1,0 +1,31 @@
+local M = {}
+
+M.highlight_groups = {
+  hint = {
+    name = "SnipeHint",
+    -- definition = { link = "CursorLineNr" },
+    definition = { link = "Boolean" },
+  },
+  text = {
+    name = "SnipeText",
+    definition = {},
+  },
+  filename = {
+    name = "SnipeFilename",
+    definition = { link = "SnipeText" },
+  },
+  dirname = {
+    name = "SnipeDirname",
+    definition = { link = "Comment" },
+  },
+}
+
+M.highlight_ns = vim.api.nvim_create_namespace("snipe")
+
+M.create_default_hl = function()
+  for _, hl_group in pairs(M.highlight_groups) do
+    vim.api.nvim_set_hl(M.highlight_ns, hl_group.name, hl_group.definition)
+  end
+end
+
+return M

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -152,9 +152,17 @@ function Snipe.default_fmt(line_format)
         })
         hl_start_index = hl_start_index + #dirname
       elseif format == "icon" then
+        local icon, hl = nil, nil
         -- try mini.icons
         if _G.MiniIcons then
-          local icon, hl = MiniIcons.get("file", item.name)
+          icon, hl = MiniIcons.get("file", item.name)
+        end
+        -- try nvim-web-devicons
+        local has_devicons, devicons = pcall(require, "nvim-web-devicons")
+        if not icon and has_devicons then
+          icon, hl = devicons.get_icon(item.name)
+        end
+        if icon then
           result = result .. icon
           table.insert(highlights, {
             first = hl_start_index,
@@ -162,10 +170,9 @@ function Snipe.default_fmt(line_format)
             hlgroup = hl,
           })
           hl_start_index = hl_start_index + #icon
+        else
+          -- ignore "icon" altogether if no supported icon provider found
         end
-        -- TODO: try nvim-web-devicons
-        --
-        -- ignore "icon" altogether if no supported icon provider found
       else
         local text, hl = nil, nil
         if type(format) == "string" then

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -100,9 +100,11 @@ function Snipe.create_buffer_formatter(buffers)
     end
     return Snipe.default_fmt({
       "icon",
+      " ",
       function(buffer)
         return buffer.basename .. string.rep(" ", max_name_length - #buffer.basename)
       end,
+      " ",
       "directory",
     })
   else -- return full name if text_align is "left"|"right", actual alignment will be done by `Menu`
@@ -126,32 +128,32 @@ function Snipe.default_fmt(line_format)
 
     for _, format in ipairs(line_format) do
       if format == "filename" then
-        result = result .. item.basename .. " "
+        result = result .. item.basename
         table.insert(highlights, {
           first = hl_start_index,
-          last = hl_start_index + #item.basename + 1,
+          last = hl_start_index + #item.basename,
           hlgroup = Highlights.highlight_groups.filename.name,
         })
-        hl_start_index = hl_start_index + #item.basename + 1
+        hl_start_index = hl_start_index + #item.basename
       elseif format == "directory" then
-        result = result .. item.dirname .. " "
+        result = result .. item.dirname
         table.insert(highlights, {
           first = hl_start_index,
-          last = hl_start_index + #item.dirname + 1,
+          last = hl_start_index + #item.dirname,
           hlgroup = Highlights.highlight_groups.dirname.name,
         })
-        hl_start_index = hl_start_index + #item.dirname + 1
+        hl_start_index = hl_start_index + #item.dirname
       elseif format == "icon" then
         -- try mini.icons
         if _G.MiniIcons then
           local icon, hl = MiniIcons.get("file", item.basename)
-          result = result .. icon .. " "
+          result = result .. icon
           table.insert(highlights, {
             first = hl_start_index,
-            last = hl_start_index + #icon + 1,
+            last = hl_start_index + #icon,
             hlgroup = hl,
           })
-          hl_start_index = hl_start_index + #icon + 1
+          hl_start_index = hl_start_index + #icon
         end
         -- TODO: try nvim-web-devicons
         --
@@ -166,13 +168,13 @@ function Snipe.default_fmt(line_format)
           -- invalid format passed, ignore
         end
         if text then
-          result = result .. text .. " "
+          result = result .. text
           table.insert(highlights, {
             first = hl_start_index,
-            last = hl_start_index + #text + 1,
+            last = hl_start_index + #text,
             hlgroup = hl or Highlights.highlight_groups.text.name,
           })
-          hl_start_index = hl_start_index + #text + 1
+          hl_start_index = hl_start_index + #text
         end
       end
     end

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -107,11 +107,13 @@ function Snipe.create_buffer_formatter(buffers)
       " ",
       "directory",
     })
-  else -- return full name if text_align is "left"|"right", actual alignment will be done by `Menu`
+  else -- return "directory/filename" if text_align is "left"|"right", actual alignment will be done by `Menu`
     return Snipe.default_fmt({
-      function(buffer)
-        return buffer.name
+      "directory",
+      function()
+        return "/", "SnipeDirname"
       end,
+      "filename",
     })
   end
 end

--- a/lua/snipe/menu.lua
+++ b/lua/snipe/menu.lua
@@ -164,9 +164,21 @@ function Menu:open(items, tag_followed, fmt, preselect)
     end
 
     for i, item in self.display_items:ipairs() do
-      local fmtd = fmt and fmt(item) or item
-      local align = (" "):rep(widest - #fmtd)
-      display_lines[i] = string.format("%s %s%s", tags[i], align, fmtd)
+      local line_string = item
+      local line_highlights = nil
+      if fmt then
+        line_string, line_highlights = fmt(item)
+      end
+      local pad = (" "):rep(widest - #line_string)
+      display_lines[i] = string.format("%s %s%s", tags[i], pad, line_string)
+      -- increase highlights first/last by pad size
+      if line_highlights ~= nil then
+        for _, hl in ipairs(line_highlights) do
+          hl.first = hl.first + #pad
+          hl.last = hl.last + #pad
+        end
+        lines_highlights[i] = line_highlights
+      end
       if #display_lines[i] > widest_line_width then
         widest_line_width = #display_lines[i]
       end


### PR DESCRIPTION
Add support for highlight groups and custom format(along the way). #69 

`text_align = "left"`
<img width="265" alt="Screenshot 2025-02-19 at 18 25 20" src="https://github.com/user-attachments/assets/8c6dd684-a261-45cf-9fdd-c3969334121f" />

`text_align="right"`
<img width="265" alt="Screenshot 2025-02-19 at 18 25 48" src="https://github.com/user-attachments/assets/f4bd8ee3-eb6f-45b4-8467-ed7660c3d54e" />

`text_align="file-first"`
<img width="309" alt="Screenshot 2025-02-19 at 18 24 47" src="https://github.com/user-attachments/assets/31920247-6bcf-409d-b430-d0cb9b46a233" />

custom `Config.ui.buffer_format`
<img width="302" alt="Screenshot 2025-02-19 at 18 57 33" src="https://github.com/user-attachments/assets/782e5bc4-5704-4c6c-a726-577c1d7fdbcb" />

**The important changes:**
1. The `Menu.open` `fmt` argument can now return a pair of a string and a list of highlight groups to apply, instead of just a string. The format of highlights is a table: `{ first: integer, last: integer, hlgroup: string}[]`.
2. The config now has a new optional property, `Config.ui.buffer_format`, which allows you to configure how the buffer is displayed in the menu. Some documentation for it has been added in the comments.
3. By default, `text_align = "file-first"` will now include an icon (if `mini.icons` is installed; support for `nvim-web-devicons` is still in the TODO).
4. New highlight groups: `SnipeHint`, `SnipeText`, `SnipeFilename`, `SnipeDirname`, with some sane defaults.

**Less important changes:**
1. Moved the highlights from `menu` to a separate module so they can be reused by other modules (like `init`).
2. Extended the `Buffer` object with new properties: `basename` and `dirname`.
3. Formatting for buffers in the menu now goes through a single pipeline, handling different `Config.ui.buffer_format` and `Config.ui.text_align` options.
4. Removed a few unnecessary "global" variables and added some types.

Open to comments, suggestions, renaming and removing things.