### PR TITLE
feat: add support for custom sort function

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,30 +54,36 @@ You can pass in a table of options to the `setup` function, here are the default
 ```lua
 {
   ui = {
+    ---@type integer
     max_height = -1, -- -1 means dynamic height
     -- Where to place the ui window
     -- Can be any of "topleft", "bottomleft", "topright", "bottomright", "center", "cursor" (sets under the current cursor pos)
+    ---@type "topleft"|"bottomleft"|"topright"|"bottomright"|"center"|"cursor"
     position = "topleft",
     -- Override options passed to `nvim_open_win`
     -- Be careful with this as snipe will not validate
     -- anything you override here. See `:h nvim_open_win`
     -- for config options
+    ---@type vim.api.keyset.win_config
     open_win_override = {
       -- title = "My Window Title",
       border = "single", -- use "rounded" for rounded border
     },
 
     -- Preselect the currently open buffer
+    ---@type boolean
     preselect_current = false,
 
     -- Set a function to preselect the currently open buffer
     -- E.g, `preselect = require("snipe").preselect_by_classifier("#")` to
     -- preselect alternate buffer (see :h ls and look at the "Indicators")
+    ---@type nil|fun(buffers: snipe.Buffer[]): number
     preselect = nil, -- function (bs: Buffer[] [see lua/snipe/buffer.lua]) -> int (index)
 
     -- Changes how the items are aligned: e.g. "<tag> foo    " vs "<tag>    foo"
     -- Can be "left", "right" or "file-first"
     -- NOTE: "file-first" puts the file name first and then the directory name
+    ---@type "left"|"right"|"file-first"
     text_align = "left",
 
     -- Provide custom buffer list format
@@ -96,6 +102,7 @@ You can pass in a table of options to the `setup` function, here are the default
   },
   hints = {
     -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)
+    ---@type string
     dictionary = "sadflewcmpghio",
   },
   navigate = {
@@ -130,8 +137,11 @@ You can pass in a table of options to the `setup` function, here are the default
     change_tag = "C",
   },
   -- The default sort used for the buffers
-  -- Can be any of "last", (sort buffers by last accessed) "default" (sort buffers by its number)
-  sort = "default"
+  -- Can be any of:
+  --  "last" - sort buffers by last accessed
+  --  "default" - sort buffers by its number
+  --  fun(bs:snipe.Buffer[]):snipe.Buffer[] - custom sort function, should accept a list of snipe.Buffer[] as an argument and return sorted list of snipe.Buffer[]
+  sort = "default",
 }
 ```
 

--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -4,30 +4,36 @@ local M = {}
 ---@class snipe.DefaultConfig
 M.defaults = {
   ui = {
+    ---@type integer
     max_height = -1, -- -1 means dynamic height
     -- Where to place the ui window
     -- Can be any of "topleft", "bottomleft", "topright", "bottomright", "center", "cursor" (sets under the current cursor pos)
+    ---@type "topleft"|"bottomleft"|"topright"|"bottomright"|"center"|"cursor"
     position = "topleft",
     -- Override options passed to `nvim_open_win`
     -- Be careful with this as snipe will not validate
     -- anything you override here. See `:h nvim_open_win`
     -- for config options
+    ---@type vim.api.keyset.win_config
     open_win_override = {
       -- title = "My Window Title",
       border = "single", -- use "rounded" for rounded border
     },
 
     -- Preselect the currently open buffer
+    ---@type boolean
     preselect_current = false,
 
     -- Set a function to preselect the currently open buffer
     -- E.g, `preselect = require("snipe").preselect_by_classifier("#")` to
     -- preselect alternate buffer (see :h ls and look at the "Indicators")
+    ---@type nil|fun(buffers: snipe.Buffer[]): number
     preselect = nil, -- function (bs: Buffer[] [see lua/snipe/buffer.lua]) -> int (index)
 
     -- Changes how the items are aligned: e.g. "<tag> foo    " vs "<tag>    foo"
     -- Can be "left", "right" or "file-first"
     -- NOTE: "file-first" puts the file name first and then the directory name
+    ---@type "left"|"right"|"file-first"
     text_align = "left",
 
     -- Provide custom buffer list format
@@ -46,6 +52,7 @@ M.defaults = {
   },
   hints = {
     -- Charaters to use for hints (NOTE: make sure they don't collide with the navigation keymaps)
+    ---@type string
     dictionary = "sadflewcmpghio",
   },
   navigate = {
@@ -80,7 +87,11 @@ M.defaults = {
     change_tag = "C",
   },
   -- The default sort used for the buffers
-  -- Can be any of "last", (sort buffers by last accessed) "default" (sort buffers by its number)
+  -- Can be any of:
+  --  "last" - sort buffers by last accessed
+  --  "default" - sort buffers by its number
+  --  fun(bs:snipe.Buffer[]):snipe.Buffer[] - custom sort function, should accept a list of snipe.Buffer[] as an argument and return sorted list of snipe.Buffer[]
+  ---@type "last"|"default"|fun(buffers:snipe.Buffer[]):snipe.Buffer[]
   sort = "default",
 }
 

--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -105,7 +105,7 @@ M.validate = function(config)
     ["navigate.open_vsplit"] = { config.navigate.open_vsplit, "string", true },
     ["navigate.open_split"] = { config.navigate.open_split, "string", true },
     ["navigate.change_tag"] = { config.navigate.change_tag, "string", true },
-    ["sort"] = { config.sort, "string", true },
+    ["sort"] = { config.sort, { "string", "function" }, true },
   }
 
   vim.validate(validation_set)

--- a/lua/snipe/init.lua
+++ b/lua/snipe/init.lua
@@ -218,10 +218,19 @@ function Snipe.preselect_by_classifier(classifier)
   end
 end
 
-function Snipe.open_buffer_menu()
+---Get the buffer list sorted in the order of the `sort` config options
+---@return snipe.Buffer[]
+function Snipe.get_sorted_buffer_list()
   local cmd = Config.sort == "last" and "ls t" or "ls"
-  ---@type snipe.Buffer[]
   local buffers = Buffer.get_buffers(cmd)
+  if type(Config.sort) == "function" then
+    return Config.sort(buffers)
+  end
+  return buffers
+end
+
+function Snipe.open_buffer_menu()
+  local buffers = Snipe.get_sorted_buffer_list()
   local format_buffer = Snipe.create_buffer_formatter(buffers)
   Snipe.global_menu:add_new_buffer_callback(Snipe.default_keymaps)
 


### PR DESCRIPTION
potentially fixes #67 , but can also be used for any type of sorting, ie. alphabetically, by filetype, etc.

sort by directory:
```lua
---sort by path
---@param buffers snipe.Buffer[]
---@return snipe.Buffer[]
sort = function(buffers)
  local buffers_with_dir = vim.tbl_map(function(buf)
    buf.dirname = vim.fs.dirname(buf.name)
    return buf
  end, buffers)

  table.sort(buffers_with_dir, function(a, b)
    if a.dirname == b.dirname then
      return a.name < b.name
    else
      return a.dirname < b.dirname
    end
  end)

  return buffers_with_dir
end
```

