### PR TITLE
FEAT: accept table for the `under_cursor` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can pass in a table of options to the `setup` function, here are the default
     -- You can also just use normal navigation to go to the item you want
     -- this option just sets the keybind for selecting the item under the
     -- cursor
+    ---@type string|string[]
     under_cursor = "<cr>",
 
     -- In case you changed your mind, provide a keybind that lets you

--- a/lua/snipe/config.lua
+++ b/lua/snipe/config.lua
@@ -85,6 +85,7 @@ M.defaults = {
     -- You can also just use normal navigation to go to the item you want
     -- this option just sets the keybind for selecting the item under the
     -- cursor
+    ---@type string|string[]
     under_cursor = "<cr>",
 
     -- In case you changed your mind, provide a keybind that lets you
@@ -138,7 +139,7 @@ M.validate = function(config)
     ["navigate.leader_map"] = { config.navigate.leader_map, "table", true },
     ["navigate.next_page"] = { config.navigate.next_page, "string", true },
     ["navigate.prev_page"] = { config.navigate.prev_page, "string", true },
-    ["navigate.under_cursor"] = { config.navigate.under_cursor, "string", true },
+    ["navigate.under_cursor"] = { config.navigate.under_cursor, { "string", "table" }, true },
     ["navigate.cancel_snipe"] = { config.navigate.cancel_snipe, { "string", "table" }, true },
     ["navigate.close_buffer"] = { config.navigate.close_buffer, "string", true },
     ["navigate.open_vsplit"] = { config.navigate.open_vsplit, "string", true },

--- a/lua/snipe/menu.lua
+++ b/lua/snipe/menu.lua
@@ -98,7 +98,11 @@ function Menu:default_keymaps(callbacks)
 
   set_keymap(keymaps.next_page, callbacks.nav_next)
   set_keymap(keymaps.prev_page, callbacks.nav_prev)
-  set_keymap(keymaps.under_cursor, callbacks.under_cursor)
+
+  local under_cursor_keys = type(keymaps.under_cursor) == "string" and { keymaps.under_cursor } or keymaps.under_cursor
+  for _, key in ipairs(under_cursor_keys or {}) do
+    set_keymap(key, callbacks.under_cursor)
+  end
 
   local cancel_keys = type(keymaps.cancel) == "string" and { keymaps.cancel } or keymaps.cancel
   for _, key in ipairs(cancel_keys or {}) do


### PR DESCRIPTION
Closes #84 